### PR TITLE
Remove KEEPASSX_EXPORT attribute from Tools::binaryFind().

### DIFF
--- a/src/core/Tools.h
+++ b/src/core/Tools.h
@@ -43,7 +43,7 @@ void disableCoreDumps();
 void setupSearchPaths();
 
 template <typename RandomAccessIterator, typename T>
-KEEPASSX_EXPORT RandomAccessIterator binaryFind(RandomAccessIterator begin, RandomAccessIterator end, const T& value)
+RandomAccessIterator binaryFind(RandomAccessIterator begin, RandomAccessIterator end, const T& value)
 {
     RandomAccessIterator it = std::lower_bound(begin, end, value);
 


### PR DESCRIPTION
It's an inline function. Declaring it as KEEPASSX_EXPORT breaks
building on Windows.

Closes #373
