### PR TITLE
Print libXtst instead of libXtest in the feature summary.

### DIFF
--- a/src/autotype/CMakeLists.txt
+++ b/src/autotype/CMakeLists.txt
@@ -2,7 +2,7 @@ if(Q_WS_X11)
   find_package(X11)
   if(PRINT_SUMMARY)
     add_feature_info(libXi X11_Xi_FOUND "The X11 Xi Protocol library is required for auto-type")
-    add_feature_info(libXtest X11_XTest_FOUND "The X11 XTEST Protocol library is required for auto-type")
+    add_feature_info(libXtst X11_XTest_FOUND "The X11 XTEST Protocol library is required for auto-type")
   endif()
 
   if(X11_FOUND AND X11_Xi_FOUND AND X11_XTest_FOUND)


### PR DESCRIPTION
The protocol is called XTEST but the library libxtst.

Closes #440
